### PR TITLE
Migrate raptor-webext benchmarks to browsertime

### DIFF
--- a/benchmarks/JetStream2/JetStreamDriver.js
+++ b/benchmarks/JetStream2/JetStreamDriver.js
@@ -416,6 +416,8 @@ class Driver {
             var _data = ['raptor-benchmark', 'jetstream2', measured];
             console.log('jetstream2 is about to post results to the raptor webext');
             window.postMessage(_data, '*');
+            // Send the results to browsertime
+            window.sessionStorage.setItem('benchmark_results',  JSON.stringify(_data));
         }
         //=================================================================================
 

--- a/benchmarks/assorted-dom/analyze-results.js
+++ b/benchmarks/assorted-dom/analyze-results.js
@@ -289,6 +289,8 @@ function postToRaptor() {
     _data = ['raptor-benchmark', 'assorted-dom', benchmark_results]
     console.log("posting results to raptor browser extension");
     window.postMessage(_data, '*');
+    // Send the results to browsertime
+    window.sessionStorage.setItem('benchmark_results',  JSON.stringify(_data));
 }
 
 window.onload = function(){

--- a/benchmarks/unity-webgl/Data/mozbench.js
+++ b/benchmarks/unity-webgl/Data/mozbench.js
@@ -46,6 +46,8 @@ function postResults() {
   if (location.search == '?raptor') {
     var _data = ['raptor-benchmark', 'unity-webgl', JSON.stringify(results)];
     window.postMessage(_data, '*');
+    // Send the results to browsertime
+    window.sessionStorage.setItem('benchmark_results',  JSON.stringify(_data));
   } else {
     var xmlHttp = new XMLHttpRequest();
     xmlHttp.open("POST", "/results", true);

--- a/benchmarks/wasm-misc/index.html
+++ b/benchmarks/wasm-misc/index.html
@@ -36,6 +36,8 @@ function finish() {
 
     _data = ['raptor-benchmark', 'wasm-misc', results];
     window.postMessage(_data, '*');
+    // Send the results to browsertime
+    window.sessionStorage.setItem('benchmark_results',  JSON.stringify(_data));
 }
 
 function instantiate(module) {


### PR DESCRIPTION
Migrate JetStream2, assorted-dom, unity-webgl and wasm-misc to browsertime.
Just add a line that sends the results that browsertime can handle.