### PR TITLE
close videoframe properly

### DIFF
--- a/benchmarks/webcodecs/benchmarks.js
+++ b/benchmarks/webcodecs/benchmarks.js
@@ -338,6 +338,7 @@ async function encodeCanvas(
       });
       frameCount += 1;
       encodeDuration += frameDuration;
+      frame.close();
     }, frameDuration);
   });
 }


### PR DESCRIPTION
Although VideoFrames will be closed automatically during garbage collection, it'd be better to close unused VideoFrames ASAP to free some space. In addition, no warnings will pop up in the debug console any more.