### PR TITLE
Add an option to generate encoding frames from camera video

### DIFF
--- a/benchmarks/webcodecs/benchmarks.js
+++ b/benchmarks/webcodecs/benchmarks.js
@@ -27,6 +27,8 @@ addTestsLoader(async function() {
   const frameDuration = Math.round(1000 / fps);
   const frameCount = Math.floor(TOTAL_DURATION / frameDuration) + 1;
 
+  let testcases = [];
+
   // Filter to configs the browser actually supports.
   let supportedConfigs = [];
   for (const c of configList) {
@@ -34,6 +36,13 @@ addTestsLoader(async function() {
     const support = await VideoEncoder.isConfigSupported(config);
     if (support.supported) {
       supportedConfigs.push(config);
+    } else {
+      let name = `${config.codec}`;
+      if (config.avc) {
+        name += ` (${config.avc.format})`;
+      }
+      testcases.push(errorTestCase(
+        `${name} ${config.latencyMode} encode`, "Config not supported"));
     }
   }
 
@@ -47,11 +56,15 @@ addTestsLoader(async function() {
     // platform-dependent limits.
     const devices = await navigator.mediaDevices.enumerateDevices();
     const cameras = devices.filter(d => d.kind == "videoinput");
-    if (cameras.length) {
+    if (!cameras.length) {
+      testcases.push(errorTestCase(
+        "camera", "No video input device found"));
+    } else {
       try {
         cameraVideo = await startCamera(width, height);
       } catch (e) {
-        // Camera setup failed; cameraVideo stays null, skipping camera tests.
+        testcases.push(errorTestCase(
+          "camera", `Setup failed: ${e.message}`));
       }
     }
   }
@@ -64,7 +77,6 @@ addTestsLoader(async function() {
     );
   }
 
-  let testcases = [];
   for (const config of supportedConfigs) {
     let baseName = `${config.codec}`;
     if (config.avc) {

--- a/benchmarks/webcodecs/benchmarks.js
+++ b/benchmarks/webcodecs/benchmarks.js
@@ -3,6 +3,7 @@ const DEFAULT_PARAMS = {
   height: 480,
   bitrate: 1000000, // 1 Mbps
   framerate: 30,
+  sources: ["canvas"],
   pixelFormats: ["RGBX"],
   latencyModes: ["realtime", "quality"],
   codecList: [
@@ -19,44 +20,73 @@ const TOTAL_DURATION = 3000; // ms
 const KEY_FRAME_INTERVAL = 15; // 1 key every 15 frames
 
 addTestsLoader(async function() {
-  const { configList, width, height, framerate, bitrate, pixelFormats } =
+  const { configList, width, height, framerate, bitrate, pixelFormats, sources } =
     parseParamsFromURL();
 
   const fps = framerate;
   const frameDuration = Math.round(1000 / fps);
   const frameCount = Math.floor(TOTAL_DURATION / frameDuration) + 1;
 
-  // Pre-generate frames once for all tests
-  const frameDataMap = await generateFrames(
-    width, height, frameCount, frameDuration, pixelFormats
-  );
+  // Filter to configs the browser actually supports.
+  let supportedConfigs = [];
+  for (const c of configList) {
+    let config = { ...c, width, height, bitrate, framerate };
+    const support = await VideoEncoder.isConfigSupported(config);
+    if (support.supported) {
+      supportedConfigs.push(config);
+    }
+  }
+
+  // Set up camera if requested and available.
+  let cameraVideo = null;
+  if (sources.includes("camera")) {
+    // Camera mode: create VideoFrames directly from the live video element
+    // during each test instead of pre-generating and storing frames.
+    // Pre-storing VideoFrame objects would risk exhausting the browser's
+    // VideoFrame resource pool, which is backed by GPU/video memory with
+    // platform-dependent limits.
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const cameras = devices.filter(d => d.kind == "videoinput");
+    if (cameras.length) {
+      try {
+        cameraVideo = await startCamera(width, height);
+      } catch (e) {
+        // Camera setup failed; cameraVideo stays null, skipping camera tests.
+      }
+    }
+  }
+
+  // Pre-generate canvas frames if needed.
+  let frameDataMap = null;
+  if (sources.includes("canvas")) {
+    frameDataMap = await generateFrames(
+      width, height, frameCount, frameDuration, pixelFormats
+    );
+  }
 
   let testcases = [];
-  for (const pixelFormat of pixelFormats) {
-    const frames = frameDataMap[pixelFormat];
-    for (const c of configList) {
-      let config = {
-        ...c, // latencyMode and avc should have been set
-        width,
-        height,
-        bitrate,
-        framerate,
-      };
-      const support = await VideoEncoder.isConfigSupported(config);
-      if (support.supported) {
-        let name = `${config.codec}`;
-        if (config.avc) {
-          name += ` (${config.avc.format})`;
+  for (const config of supportedConfigs) {
+    let baseName = `${config.codec}`;
+    if (config.avc) {
+      baseName += ` (${config.avc.format})`;
+    }
+
+    for (const source of sources) {
+      if (source == "camera") {
+        if (!cameraVideo) {
+          continue;
         }
-        if (pixelFormats.length > 1 || pixelFormat != "RGBX") {
-          name += ` ${pixelFormat}`;
-        }
+        // Pixel format selection is skipped for camera since it provides
+        // frames in its native format.
+        let name = `${baseName} camera`;
 
         if (config.latencyMode == "realtime") {
           testcases.push({
             name: `${name} realtime encode`,
             func: async function() {
-              return await realtimeEncodeTest(config, frames, frameDuration);
+              return await realtimeEncodeTestFromCamera(
+                config, cameraVideo, frameDuration, frameCount
+              );
             }
           });
         }
@@ -65,9 +95,34 @@ addTestsLoader(async function() {
           testcases.push({
             name: `${name} quality encode`,
             func: async function() {
-              return await qualityEncodeTest(config, frames);
+              return await qualityEncodeTestFromCamera(
+                config, cameraVideo, frameCount, frameDuration
+              );
             }
           });
+        }
+      } else {
+        for (const pixelFormat of pixelFormats) {
+          const frames = frameDataMap[pixelFormat];
+          let name = `${baseName} ${pixelFormat} canvas`;
+
+          if (config.latencyMode == "realtime") {
+            testcases.push({
+              name: `${name} realtime encode`,
+              func: async function() {
+                return await realtimeEncodeTest(config, frames, frameDuration);
+              }
+            });
+          }
+
+          if (config.latencyMode == "quality") {
+            testcases.push({
+              name: `${name} quality encode`,
+              func: async function() {
+                return await qualityEncodeTest(config, frames);
+              }
+            });
+          }
         }
       }
     }
@@ -115,7 +170,12 @@ function parseParamsFromURL() {
         latencyModes.map(latencyMode => ({ ...config, latencyMode }))
       );
 
-  return { configList, width, height, framerate, bitrate, pixelFormats };
+  const sources = params
+    .get("sources")
+    ?.split(",")
+    .filter(s => s == "canvas" || s == "camera") || DEFAULT_PARAMS.sources;
+
+  return { configList, width, height, framerate, bitrate, pixelFormats, sources };
 }
 
 // --- Frame pre-generation ---
@@ -266,6 +326,75 @@ function createFrameFromData(frameData) {
   });
 }
 
+// --- Camera ---
+
+async function startCamera(width, height) {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    video: { width, height },
+    audio: false,
+  });
+  const video = document.createElement("video");
+  video.autoplay = true;
+  video.muted = true;
+  video.srcObject = stream;
+  await video.play();
+  // Wait until a video frame is actually available for capture.
+  // requestVideoFrameCallback fires when a frame is presented, which is the
+  // reliable signal that new VideoFrame(video) will succeed.
+  await new Promise(resolve => video.requestVideoFrameCallback(resolve));
+
+  const container = document.createElement("div");
+  const label = document.createElement("div");
+  label.textContent = "Camera preview";
+  container.appendChild(label);
+  video.style.width = `${width}px`;
+  video.style.height = `${height}px`;
+  container.appendChild(video);
+  container.style.display = "none";
+  document.body.appendChild(container);
+
+  return video;
+}
+
+async function feedFramesFromCameraRealtime(
+  worker, video, frameDuration, frameCount, keyFrameIntervalInFrames
+) {
+  let frameIndex = 0;
+  return new Promise((resolve) => {
+    const intervalId = setInterval(() => {
+      if (frameIndex >= frameCount) {
+        clearInterval(intervalId);
+        resolve();
+        return;
+      }
+      const timestamp = frameIndex * frameDuration;
+      const frame = new VideoFrame(video, { timestamp });
+      worker.postMessage({
+        command: "encode",
+        frame,
+        isKey: frameIndex % keyFrameIntervalInFrames == 0,
+      });
+      frame.close();
+      frameIndex++;
+    }, frameDuration);
+  });
+}
+
+function feedFramesFromCameraBatch(
+  worker, video, frameCount, frameDuration, keyFrameIntervalInFrames
+) {
+  for (let i = 0; i < frameCount; i++) {
+    const timestamp = i * frameDuration;
+    const frame = new VideoFrame(video, { timestamp });
+    worker.postMessage({
+      command: "encode",
+      frame,
+      isKey: i % keyFrameIntervalInFrames == 0,
+    });
+    frame.close();
+  }
+}
+
 // --- Frame feeding ---
 
 async function feedFramesRealtime(
@@ -308,14 +437,7 @@ function feedFramesBatch(worker, frames, keyFrameIntervalInFrames) {
 
 // --- Test functions ---
 
-async function realtimeEncodeTest(config, frames, frameDuration) {
-  const worker = new Worker("encoder-worker.js");
-  config.latencyMode = "realtime";
-  configureEncoder(worker, config);
-
-  await feedFramesRealtime(worker, frames, frameDuration, KEY_FRAME_INTERVAL);
-  let { encodeTimes, outputTimes } = await getEncoderResults(worker);
-
+function computeRealtimeStats(encodeTimes, outputTimes) {
   let results = { key: {}, delta: {} };
   results.key.encodeTimes = encodeTimes.filter(x => x.type == "key");
   results.delta.encodeTimes = encodeTimes.filter(x => x.type != "key");
@@ -345,8 +467,6 @@ async function realtimeEncodeTest(config, frames, frameDuration) {
     results.delta.roundTripTimes.map(x => x.time)
   );
 
-  worker.terminate();
-
   return {
     "frame-to-frame mean (key)": {
       value: results.key.roundTripResult.mean,
@@ -375,6 +495,30 @@ async function realtimeEncodeTest(config, frames, frameDuration) {
   };
 }
 
+async function realtimeEncodeTest(config, frames, frameDuration) {
+  const worker = new Worker("encoder-worker.js");
+  config.latencyMode = "realtime";
+  configureEncoder(worker, config);
+  await feedFramesRealtime(worker, frames, frameDuration, KEY_FRAME_INTERVAL);
+  let { encodeTimes, outputTimes } = await getEncoderResults(worker);
+  worker.terminate();
+  return computeRealtimeStats(encodeTimes, outputTimes);
+}
+
+async function realtimeEncodeTestFromCamera(config, video, frameDuration, frameCount) {
+  video.parentNode.style.display = "";
+  const worker = new Worker("encoder-worker.js");
+  config.latencyMode = "realtime";
+  configureEncoder(worker, config);
+  await feedFramesFromCameraRealtime(
+    worker, video, frameDuration, frameCount, KEY_FRAME_INTERVAL
+  );
+  let { encodeTimes, outputTimes } = await getEncoderResults(worker);
+  worker.terminate();
+  video.parentNode.style.display = "none";
+  return computeRealtimeStats(encodeTimes, outputTimes);
+}
+
 async function qualityEncodeTest(config, frames) {
   const worker = new Worker("encoder-worker.js");
   config.latencyMode = "quality";
@@ -387,6 +531,24 @@ async function qualityEncodeTest(config, frames) {
 
   worker.terminate();
 
+  return {
+    "first encode to last output": {
+      value: duration,
+      unit: "ms",
+    },
+  };
+}
+
+async function qualityEncodeTestFromCamera(config, video, frameCount, frameDuration) {
+  video.parentNode.style.display = "";
+  const worker = new Worker("encoder-worker.js");
+  config.latencyMode = "quality";
+  configureEncoder(worker, config);
+  feedFramesFromCameraBatch(worker, video, frameCount, frameDuration, KEY_FRAME_INTERVAL);
+  let { encodeTimes, outputTimes } = await getEncoderResults(worker);
+  let duration = getTotalDuration(encodeTimes, outputTimes);
+  worker.terminate();
+  video.parentNode.style.display = "none";
   return {
     "first encode to last output": {
       value: duration,

--- a/benchmarks/webcodecs/index.html
+++ b/benchmarks/webcodecs/index.html
@@ -24,6 +24,21 @@
   #in-progress {
     display: none;
   }
+  #errors {
+    display: none;
+    margin: 1em;
+    padding: 0.5em;
+    border: 1px solid red;
+    background-color: #fff0f0;
+    color: red;
+  }
+  #errors h3 {
+    margin: 0 0 0.5em 0;
+  }
+  #errors ul {
+    margin: 0;
+    padding-left: 1.5em;
+  }
 </style>
 </head>
 <body>
@@ -33,6 +48,10 @@
     <progress id=progress-bar> </progress>
     <span id=progress-label>Benchmark in progress...</span>
   </div>
+</div>
+<div id=errors>
+  <h3>Errors</h3>
+  <ul id=error-list></ul>
 </div>
 <div id=results>
 </div>

--- a/benchmarks/webcodecs/webcodecs-bench.js
+++ b/benchmarks/webcodecs/webcodecs-bench.js
@@ -22,6 +22,23 @@ function showResults(results, title) {
   container.appendChild(table);
 }
 
+function showError(message) {
+  const errors = document.getElementById("errors");
+  errors.style.display = "block";
+  const li = document.createElement("li");
+  li.textContent = message;
+  document.getElementById("error-list").appendChild(li);
+}
+
+function errorTestCase(name, message) {
+  return {
+    name,
+    func: async function() {
+      return { "error": { value: message, unit: "" } };
+    }
+  };
+}
+
 function sendResults(results) {
   let data = ["raptor-benchmark", "webcodecs", JSON.stringify(results)];
   window.postMessage(data, "*");
@@ -36,10 +53,24 @@ async function runTests(testcases) {
   let testResults = {};
   for (let i = 0; i < testcases.length; i++) {
     console.assert(!testResults.hasOwnProperty(testcases[i].name));
-    let results = await testcases[i].func();
+    try {
+      let results = await testcases[i].func();
+      if (results.error) {
+        showError(`${testcases[i].name}: ${results.error.value}`);
+      } else {
+        showResults(results, testcases[i].name);
+      }
+      testResults[testcases[i].name] = results;
+    } catch (e) {
+      // This may happen if the camera disconnects mid-test, causing
+      // new VideoFrame(video) to throw in the frame feed functions.
+      let msg = `${testcases[i].name}: ${e.message}`;
+      showError(msg);
+      testResults[testcases[i].name] = {
+        "error": { value: msg, unit: "" },
+      };
+    }
     document.getElementById("progress-bar").value++;
-    showResults(results, testcases[i].name);
-    testResults[testcases[i].name] = results;
   }
   document.getElementById("in-progress").style.display = "none";
   sendResults(testResults);


### PR DESCRIPTION
This PR is based on PR #41 and introduces an option for generating encoding frames from the video element that constantly capturing the camera video. Additionally, this PR also creates a `testcase` that cannot be parsed for statistics but able to propagate the error messages to CI for debugging issues (e.g., permission-denial or lack of camera devices). 

(note: Rebase is needed once #41 is merged)

## Summary

- Add sources URL parameter supporting canvas (default) and camera, allowing multiple sources (e.g., sources=canvas,camera)
- Camera mode uses `getUserMedia` to capture live frames and feeds them directly to the encoder without pre-generation, avoiding `VideoFrame` resource pool exhaustion
- Check for video input devices before attempting camera setup; skip camera tests gracefully if no device is available
- Hoist `VideoEncoder.isConfigSupported` check before the source loop to eliminate duplicate calls
- Add dedicated error display section on the page and propagate errors through benchmark results for CI visibility
- Report unsupported configs and camera setup failures through the same errorTestCase channel

## Tests

- Start a local server: `cd benchmarks/webcodecs && python3 -m http.server 8080`
- Test canvas only (default): http://localhost:8080/index.html?codecs=avc1.42001E:annexb&latencyModes=realtime,quality&width=640&height=480&framerate=30
- Test camera (requires camera or fake device): http://localhost:8080/index.html?sources=camera&codecs=avc1.42001E:annexb&latencyModes=realtime,quality&width=640&height=480&framerate=30
- Test both sources: http://localhost:8080/index.html?sources=canvas,camera&codecs=avc1.42001E:annexb&latencyModes=realtime,quality&width=640&height=480&framerate=30
- Test without camera (verify error display): http://localhost:8080/index.html?sources=camera&codecs=avc1.42001E:annexb&latencyModes=realtime&width=640&height=480&framerate=30 on a machine with no camera
- Test unsupported codec (verify error display): http://localhost:8080/index.html?codecs=unsupported&latencyModes=realtime&width=640&height=480&framerate=30
- Verified error propagation in CI with intentionally broken camera prefs — error message appears in raptor task log